### PR TITLE
Adding Gringotts Payment Library in development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1410,6 +1410,7 @@ There are [other sites with curated lists of elixir packages](#other-awesome-lis
 * [gcmex](https://github.com/dukex/gcmex) - Google Cloud Messaging client library for elixir.
 * [google_sheets](https://github.com/GrandCru/GoogleSheets) - Elixir library for fetching and polling Google spreadsheet data in CSV format.
 * [govtrack](https://github.com/walterbm/govtrack-elixir) - A simple Elixir wrapper for the [govtrack.us](https://www.govtrack.us/developers) API.
+* [gringotts](https://github.com/aviabird/gringotts) -A complete payment library for Elixir and Phoenix Framework.
 * [hexoku](https://github.com/JonGretar/Hexoku) - Heroku API client and Heroku Mix tasks for Elixir projects.
 * [honeywell](https://github.com/jeffutter/honeywell-elixir) - A client for the Honeywell Lyric, Round and Water Leak & Freeze Detector APIs.
 * [kane](https://github.com/peburrows/kane) - A [Google Cloud Pub/Sub](https://cloud.google.com/pubsub/overview) client.


### PR DESCRIPTION
Gringotts is a payment processing library in Elixir integrating various payment gateways, this draws motivation for shopify's active merchant gem.

A simple and unified API to access dozens of different payment gateways with very different internal APIs is what Gringotts has to offer you.